### PR TITLE
Added audio context as singleton

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "stage-0"]
+  "presets": ["es2015", "stage-0"],
+  "plugins": ["rewire"]
 }

--- a/README.md
+++ b/README.md
@@ -33,30 +33,6 @@ To run in the browser at [http://localhost:8080](http://localhost:8080), do:
 $ npm start
 ```
 
-You can test the synth in the console:
-
-```js
-osc
-  .setWaveformType('square')
-  .setFrequency(50)
-  .setDetune(4);
-
-osc.start();
-```
-
-You can experiment with changing oscillator parameters by running the set and transition methods exposed by the `Oscillator`, e.g.:
-
-```js
-osc.setFrequency(1200);
-// immediately set the frequency to 1.2kHz
-
-osc.transitionFrequency(600, 3);
-// transition the frequency setting to 600Hz over 3 seconds
-
-osc.transitionDetune(86, 2);
-// transition the detune setting to 86 over 2 seconds
-```
-
 ## Development
 
 To watch for changes and refresh browser window (requires [LiveReload plugin](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en) for Chrome):

--- a/examples/SingleOscSynth.js
+++ b/examples/SingleOscSynth.js
@@ -49,21 +49,19 @@ export default class SingleOscSynth extends Synth
       .setMin(200)
       .setMax(1500)
       .setStep(20)
-      .control(osc1, osc2.setFrequency);
+      .control(osc2, osc2.setFrequency);
 
     document.body.appendChild(oscFrequencyControl2.el);
 
-
-let oscFrequencyControl3 = new Slider(document, 'Osc Freq');
+    let oscFrequencyControl3 = new Slider(document, 'Osc Freq');
 
     oscFrequencyControl3
       .setMin(200)
       .setMax(1500)
       .setStep(20)
-      .control(osc1, osc3.setFrequency);
+      .control(osc3, osc3.setFrequency);
 
     document.body.appendChild(oscFrequencyControl3.el);
-
 
     // testing
     window.synth = this;

--- a/examples/SingleOscSynth.js
+++ b/examples/SingleOscSynth.js
@@ -16,11 +16,11 @@ export default class SingleOscSynth extends Synth
    */
   on()
   {
-    let osc1 = new Oscillator(this.ctx);
-    let osc2 = new Oscillator(this.ctx);
-    let osc3 = new Oscillator(this.ctx);
-    let filter = new Filter(this.ctx);
-    let mixer = new Mixer(this.ctx);
+    let osc1 = new Oscillator();
+    let osc2 = new Oscillator();
+    let osc3 = new Oscillator();
+    let filter = new Filter();
+    let mixer = new Mixer();
 
     this.addModule(osc1);
     this.addModule(osc2);

--- a/examples/main.js
+++ b/examples/main.js
@@ -1,7 +1,4 @@
 import SingleOscSynth from './SingleOscSynth.js';
 
-let AudioContext = window.AudioContext || window.webkitAudioContext;
-let ctx = new AudioContext();
-
-let synth = new SingleOscSynth(ctx);
+let synth = new SingleOscSynth();
 synth.on();

--- a/lib/Filter.js
+++ b/lib/Filter.js
@@ -1,10 +1,11 @@
+import ctx from 'audio-context';
+
 export default class Filter
 {
 
-	constructor(ctx)
+	constructor()
 	{
-		this.ctx = ctx;
-		this.node = this.ctx.createBiquadFilter();
+		this.node = ctx.createBiquadFilter();
 	}
 
 	setFreq(frequency)

--- a/lib/Gain.js
+++ b/lib/Gain.js
@@ -1,3 +1,5 @@
+import ctx from 'audio-context';
+
 /*Creating a Gain class to use Globally in multiple
 applications (such as multi-channel mixer)
 */
@@ -5,10 +7,9 @@ export default class Gain
 
 {
 	
-	constructor(ctx)
+	constructor()
 	{
-		this.ctx = ctx;
-		this.node = this.ctx.createGain();
+		this.node = ctx.createGain();
 	}
 	
 	setGain(volume)

--- a/lib/Gain.js
+++ b/lib/Gain.js
@@ -3,17 +3,16 @@ import ctx from 'audio-context';
 /*Creating a Gain class to use Globally in multiple
 applications (such as multi-channel mixer)
 */
-export default class Gain 
+export default class Gain
 
 {
-	
-	constructor()
-	{
-		this.node = ctx.createGain();
-	}
-	
-	setGain(volume)
-	{
-		return this.node.gain.value = volume;
-	}
+  constructor()
+  {
+    this.node = ctx.createGain();
+  }
+
+  setGain(volume)
+  {
+    return this.node.gain.value = volume;
+  }
 }

--- a/lib/Mixer.js
+++ b/lib/Mixer.js
@@ -1,16 +1,16 @@
 // Creating a multi-channel mixer to use in synth
+import ctx from 'audio-context';
 import Gain from './Gain.js';
 export default class Mixer
 {
 
-  constructor(ctx)
+  constructor()
   {
-    this.ctx = ctx;
-    this.node = this.ctx.createChannelMerger(3);
+    this.node = ctx.createChannelMerger(3);
 
-    this.addChildModule('ch1', new Gain(ctx));
-    this.addChildModule('ch2', new Gain(ctx));
-    this.addChildModule('ch3', new Gain(ctx));
+    this.addChildModule('ch1', new Gain());
+    this.addChildModule('ch2', new Gain());
+    this.addChildModule('ch3', new Gain());
   }
 
   addChildModule(id, module)

--- a/lib/Mixer.js
+++ b/lib/Mixer.js
@@ -1,6 +1,7 @@
-// Creating a multi-channel mixer to use in synth
 import ctx from 'audio-context';
 import Gain from './Gain.js';
+
+// Creating a multi-channel mixer to use in synth
 export default class Mixer
 {
 

--- a/lib/Oscillator.js
+++ b/lib/Oscillator.js
@@ -1,16 +1,14 @@
+import ctx from 'audio-context';
+
 /**
  * Thin wrapper around the OscillatorNode API that exposes
  * convenient methods for interacting with parameters
  */
 export default class Oscillator
 {
-  /**
-   * @param {AudioContext} ctx
-   */
-  constructor(ctx)
+  constructor()
   {
-    this.ctx = ctx;
-    this.node = this.ctx.createOscillator();
+    this.node = ctx.createOscillator();
   }
 
   /**
@@ -91,35 +89,5 @@ export default class Oscillator
   getWaveformType()
   {
     return this.node.type;
-  }
-
-  /**
-   * @param {number} value
-   * @param {number} duration in seconds
-   * @return {Oscillator}
-   */
-  transitionFrequency(value, duration)
-  {
-    let freq = this.node.frequency;
-
-    freq.linearRampToValueAtTime(freq.value, this.ctx.currentTime);
-    freq.linearRampToValueAtTime(value, this.ctx.currentTime + duration);
-
-    return this;
-  }
-
-  /**
-   * @param {number} value
-   * @param {number} duration in seconds
-   * @return {Oscillator}
-   */
-  transitionDetune(value, duration)
-  {
-    let detune = this.node.detune;
-
-    detune.linearRampToValueAtTime(detune.value, this.ctx.currentTime);
-    detune.linearRampToValueAtTime(value, this.ctx.currentTime + duration);
-
-    return this;
   }
 }

--- a/lib/Synth.js
+++ b/lib/Synth.js
@@ -1,15 +1,13 @@
+import ctx from 'audio-context';
+
 /**
  * Composable synth container for connecting
  * audio modules
  */
 export default class Synth
 {
-  /**
-   * @param {AudioContext} ctx
-   */
-  constructor(ctx)
+  constructor()
   {
-    this.ctx = ctx;
     this._modules = [];
     this._connecting = null;
   }
@@ -90,7 +88,7 @@ export default class Synth
    */
   output()
   {
-    this._connecting.node.connect(this.ctx.destination);
+    this._connecting.node.connect(ctx.destination);
     this._connecting = null;
 
     return this;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "debug": "^2.1.0"
   },
   "devDependencies": {
+    "babel-core": "^6.4.5",
+    "babel-plugin-rewire": "1.0.0-beta-3",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "babel-register": "^6.4.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "Zak Angelle, Drake Champagne",
   "license": "MIT",
   "dependencies": {
+    "audio-context": "^0.1.0",
     "bluebird": "^2.3.11",
     "debug": "^2.1.0"
   },

--- a/test/oscillator.js
+++ b/test/oscillator.js
@@ -5,6 +5,12 @@ import Oscillator from '../lib/Oscillator.js';
 test('Set frequency', (t) => {
   t.plan(1);
 
+  var ctx = nm.mock('createOscillator').takes().returns({
+   frequency: { value: 0 }
+  });
+
+  Oscillator.__Rewire__('ctx', ctx);
+
   var osc = new Oscillator();
   osc.setFrequency(500);
 
@@ -13,6 +19,12 @@ test('Set frequency', (t) => {
 
 test('Set detune', (t) => {
   t.plan(1);
+
+  var ctx = nm.mock('createOscillator').takes().returns({
+   detune: { value: 0 }
+  });
+
+  Oscillator.__Rewire__('ctx', ctx);
 
   var osc = new Oscillator();
   osc.setDetune(72);
@@ -23,6 +35,12 @@ test('Set detune', (t) => {
 test('Set waveform type', (t) => {
   t.plan(1);
 
+  var ctx = nm.mock('createOscillator').takes().returns({
+   type: ''
+  });
+
+  Oscillator.__Rewire__('ctx', ctx);
+
   var osc = new Oscillator();
   osc.setWaveformType('sawtooth');
 
@@ -32,6 +50,12 @@ test('Set waveform type', (t) => {
 test('Get frequency', (t) => {
   t.plan(1);
 
+  var ctx = nm.mock('createOscillator').takes().returns({
+   frequency: { value: 1500 }
+  });
+
+  Oscillator.__Rewire__('ctx', ctx);
+
   var osc = new Oscillator();
 
   t.strictEquals(osc.getFrequency(), 1500);
@@ -40,6 +64,12 @@ test('Get frequency', (t) => {
 test('Get detune', (t) => {
   t.plan(1);
 
+  var ctx = nm.mock('createOscillator').takes().returns({
+   detune: { value: 4 }
+  });
+
+  Oscillator.__Rewire__('ctx', ctx);
+
   var osc = new Oscillator();
 
   t.strictEquals(osc.getDetune(), 4);
@@ -47,6 +77,12 @@ test('Get detune', (t) => {
 
 test('Get waveform type', (t) => {
   t.plan(1);
+
+  var ctx = nm.mock('createOscillator').takes().returns({
+    type: 'sine'
+  });
+
+  Oscillator.__Rewire__('ctx', ctx);
 
   var osc = new Oscillator();
 

--- a/test/oscillator.js
+++ b/test/oscillator.js
@@ -5,11 +5,7 @@ import Oscillator from '../lib/Oscillator.js';
 test('Set frequency', (t) => {
   t.plan(1);
 
-  var ctx = nm.mock('createOscillator').takes().returns({
-   frequency: { value: 0 }
-  });
-
-  var osc = new Oscillator(ctx);
+  var osc = new Oscillator();
   osc.setFrequency(500);
 
   t.strictEquals(500, osc.node.frequency.value);
@@ -18,11 +14,7 @@ test('Set frequency', (t) => {
 test('Set detune', (t) => {
   t.plan(1);
 
-  var ctx = nm.mock('createOscillator').takes().returns({
-   detune: { value: 0 }
-  });
-
-  var osc = new Oscillator(ctx);
+  var osc = new Oscillator();
   osc.setDetune(72);
 
   t.strictEquals(72, osc.node.detune.value);
@@ -31,11 +23,7 @@ test('Set detune', (t) => {
 test('Set waveform type', (t) => {
   t.plan(1);
 
-  var ctx = nm.mock('createOscillator').takes().returns({
-   type: ''
-  });
-
-  var osc = new Oscillator(ctx);
+  var osc = new Oscillator();
   osc.setWaveformType('sawtooth');
 
   t.strictEquals('sawtooth', osc.node.type);
@@ -44,11 +32,7 @@ test('Set waveform type', (t) => {
 test('Get frequency', (t) => {
   t.plan(1);
 
-  var ctx = nm.mock('createOscillator').takes().returns({
-   frequency: { value: 1500 }
-  });
-
-  var osc = new Oscillator(ctx);
+  var osc = new Oscillator();
 
   t.strictEquals(osc.getFrequency(), 1500);
 });
@@ -56,11 +40,7 @@ test('Get frequency', (t) => {
 test('Get detune', (t) => {
   t.plan(1);
 
-  var ctx = nm.mock('createOscillator').takes().returns({
-   detune: { value: 4 }
-  });
-
-  var osc = new Oscillator(ctx);
+  var osc = new Oscillator();
 
   t.strictEquals(osc.getDetune(), 4);
 });
@@ -68,11 +48,7 @@ test('Get detune', (t) => {
 test('Get waveform type', (t) => {
   t.plan(1);
 
-  var ctx = nm.mock('createOscillator').takes().returns({
-    type: 'sine'
-  });
-
-  var osc = new Oscillator(ctx);
+  var osc = new Oscillator();
 
   t.strictEquals(osc.getWaveformType(), 'sine');
 });


### PR DESCRIPTION
This allows us to import our audio context as a singleton via `import ctx from 'audio-context'` rather than instantiating it in our implementation and passing it around the audio modules.