### PR TITLE
Add synth support for setting explicit inputNode and outputNode

### DIFF
--- a/lib/modules/Synth.js
+++ b/lib/modules/Synth.js
@@ -76,6 +76,7 @@ export default class Synth
 
   /**
    * Chain current output module into a given input
+   * Check for `inputNode` and `outputNode` and use `node` otherwise
    * @param {instance} input
    * @return {Synth}
    */
@@ -85,8 +86,11 @@ export default class Synth
       throw new Error('connect() must be called with a module before calling to()');
     }
 
+    let inputNode = input.inputNode || input.node;
+    let outputNode = this._connecting.outputNode || this._connecting.node;
+
     this._ensureModuleIsAdded(input);
-    this._connecting.node.connect(input.node);
+    outputNode.connect(inputNode);
     this._connecting = input;
 
     return this;
@@ -102,7 +106,9 @@ export default class Synth
       throw new Error('connect() must be called with a module before calling output()');
     }
 
-    this._connecting.node.connect(ctx.destination);
+    let outputNode = this._connecting.outputNode || this._connecting.node;
+
+    outputNode.connect(ctx.destination);
     this._connecting = null;
 
     return this;


### PR DESCRIPTION
This allows you to set the `inputNode` and `outputNode` of an audio module explicitly. Otherwise, the `Synth` will use `node` for both the input and output.

```js
export default class SomeAudioModule
{
  constructor()
  {
    this.inputNode = ctx.createShit();
    this.outputNode = ctx.createOtherShit();

    this.inputNode.connect(this.outputNode);
    // [input] -> this.inputNode -> this.outputNode -> [output]
  }
}
```